### PR TITLE
Fix race condition in multisite

### DIFF
--- a/src/GenerateAltText.php
+++ b/src/GenerateAltText.php
@@ -28,13 +28,12 @@ class GenerateAltText
     public function generate(): void
     {
         $altFieldMappings = ! empty(config('statamic.aida.alt_field_mapping')) ? config('statamic.aida.alt_field_mapping') : $this->generateDefaultAltFieldMappings();
-        foreach ($altFieldMappings as $locale => $fieldName) {
-            // Skip generation if overwriting is disabled and the asset already has an alt text
-            if (! $this->overwrite && $this->assetHasAltText($this->asset, $fieldName)) {
-                continue;
-            }
 
-            GenerateAltTextJob::dispatch($this->asset->id(), $locale, $fieldName);
+        $altFieldsToGenerate = collect($altFieldMappings)
+            ->reject(fn ($fieldName) => ! $this->overwrite && $this->assetHasAltText($this->asset, $fieldName));
+
+        if ($altFieldsToGenerate->isNotEmpty()) {
+            GenerateAltTextJob::dispatch($this->asset->id(), $altFieldsToGenerate->all());
         }
     }
 


### PR DESCRIPTION
I'm using this addon in a multisite and noticed that some alt fields were randomly missing here and there. The issue seems to be that individual `$asset->save()` calls conflict with each other. Probably a race condition type of thing.

This PR fixes the issue by generating all fields in one job instead of dispatching individual jobs per locale.