### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ jobs:
   create_release:
     name: Create and Publish Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Potential fix for [https://github.com/21stdigital/statamic-aida/security/code-scanning/3](https://github.com/21stdigital/statamic-aida/security/code-scanning/3)

Generally, the fix is to declare an explicit `permissions` section in the workflow (either at the root level or within the specific job) to restrict the `GITHUB_TOKEN` to the minimum scopes needed. This prevents the workflow from inheriting broader organization/repository defaults and clearly documents what the workflow is allowed to do.

For this workflow, semantic-release is meant to create GitHub releases and update tags/commits via a token. Since it already uses `secrets.SEMANTIC_RELEASE_TOKEN` for that purpose, the built-in `GITHUB_TOKEN` does not need broad write permissions. To satisfy CodeQL while not changing current behavior, we can restrict `GITHUB_TOKEN` to read-only access to repository contents. The most targeted way, without affecting other workflows, is to add a `permissions` block under the `create_release` job. Concretely, in `.github/workflows/release.yml`, under `create_release:` (around line 7), add:

```yaml
    permissions:
      contents: read
```

so that the job-level token is read-only. No additional imports, methods, or definitions are required for this YAML change, and semantic-release will continue to use `SEMANTIC_RELEASE_TOKEN` for any required write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
